### PR TITLE
feat:(sh) Change apollo config `eureka.instance.ip-address`

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -63,7 +63,7 @@ portal_url=http://localhost:8070
 # JAVA OPTS
 BASE_JAVA_OPTS="$JAVA_OPTS -Denv=dev"
 CLIENT_JAVA_OPTS="$BASE_JAVA_OPTS -Dapollo.meta=$config_server_url"
-SERVER_JAVA_OPTS="$BASE_JAVA_OPTS -Dspring.profiles.active=github -Deureka.service.url=$eureka_service_url"
+SERVER_JAVA_OPTS="$BASE_JAVA_OPTS -Dspring.profiles.active=github -Deureka.service.url=$eureka_service_url -Deureka.instance.ip-address=127.0.0.1"
 PORTAL_JAVA_OPTS="$BASE_JAVA_OPTS -Ddev_meta=$config_server_url -Dspring.profiles.active=github,auth -Deureka.client.enabled=false -Dhibernate.query.plan_cache_max_size=192"
 
 # executable


### PR DESCRIPTION
It is recommenbed that if you are useing default built-in registration center,add `-Deureka.instance.ip-address=127.0.0.1` parameter. Because the current IP is used by default,it is currently the internal IP of the container(172.17.0.1/24), which is okay it can not be provided to outside calls. Useing scenarios such as (`javasdk/openapi`), it is vert useful to verify these functions. Because the `RemoteConfigRepository` in `apollo-client` uses the registration address of the service to send the request. Then get the relavant configuration infomation.

The log is as follows:

Success:
Long polling from http://127.0.0.1:8080/notifications/v2?cluster=default&appId=SampleApp&ip=192.168.12.113&。。。

Fail:
Long polling from http://172.17.0.3:8080/notifications/v2?cluster=default&appId=SampleApp&ip=192.168.12.113&。。。


# Note
You need to rebuild the `apollo-quick-start` container.

`docker build -t nobodyiam/apollo-quick-start . -f ./Dockerfile`