### PR TITLE
upgrade jdk to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,33 @@
 # docker build -t nobodyiam/apollo-quick-start .
 # Run with:
 # docker-compose up
+# or if you are using a machine with an ARM architecture, such as a Mac M1, run with:
+# docker-compose -f docker-compose-arm64.yml up
 
-FROM openjdk:8-jre-alpine
-MAINTAINER nobodyiam<https://github.com/nobodyiam>
+FROM eclipse-temurin:17-jre
 
+LABEL maintainer="nobodyiam<https://github.com/nobodyiam>"
+
+# Copy necessary files into the image
 COPY apollo-all-in-one.jar /apollo-quick-start/apollo-all-in-one.jar
+COPY apollo-all-in-one.conf /apollo-quick-start/apollo-all-in-one.conf
 COPY client /apollo-quick-start/client
 COPY demo.sh /apollo-quick-start/demo.sh
-COPY portal/apollo-portal.conf /apollo-quick-start/portal/apollo-portal.conf
-COPY service/apollo-service.conf /apollo-quick-start/service/apollo-service.conf
 
+# Expose the necessary ports
 EXPOSE 8070 8080
 
-RUN echo "http://mirrors.aliyun.com/alpine/v3.6/main" > /etc/apk/repositories \
-    && echo "http://mirrors.aliyun.com/alpine/v3.6/community" >> /etc/apk/repositories \
-    && apk update upgrade \
-    && apk add --no-cache curl bash \
-    && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
-    && echo "Asia/Shanghai" > /etc/timezone \
-    && sed -i'.bak' '/db_url/s/localhost/apollo-db/g' /apollo-quick-start/demo.sh \
-    && sed -i "s/exit 0;/tail -f \/dev\/null/g" /apollo-quick-start/demo.sh
+# Install dependencies, set timezone, and modify the demo.sh script
+RUN apt-get update && \
+    apt-get install -y curl bash tzdata && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Set the timezone to Asia/Shanghai
+    ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone && \
+    # Modify demo.sh script
+    sed -i'.bak' '/db_url/s/localhost/apollo-db/g' /apollo-quick-start/demo.sh && \
+    sed -i "s/exit 0;/tail -f \/dev\/null/g" /apollo-quick-start/demo.sh
 
+# Set the default command to execute the demo.sh script
 CMD ["/apollo-quick-start/demo.sh", "start"]


### PR DESCRIPTION
also fixes #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker base image to `eclipse-temurin:17-jre` for better performance and compatibility.
  - Changed maintainer label format for standardization.
  - Updated package installation process to use `apt-get`.

- **Improvements**
  - Set the default timezone to Asia/Shanghai.
  - Adjusted the `demo.sh` script for smoother execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->